### PR TITLE
fix: parser hang on file-scope calls and unify window title

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -61,7 +61,7 @@ namespace {
 // Sets the window title and icon, fixes the initial size, and builds menus,
 // toolbar, and central widget.
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
-    setWindowTitle("Lexer");
+    setWindowTitle("C Compiler");
     setWindowIcon(makeAppIcon());
     resize(1280, 760);
     buildMenus();
@@ -257,6 +257,6 @@ void MainWindow::onOpenFile() {
     }
 
     editor_->setPlainText(QTextStream(&file).readAll());
-    setWindowTitle("UNI-C Compiler  -  " + QFileInfo(path).fileName());
+    setWindowTitle("C Compiler  -  " + QFileInfo(path).fileName());
     statusBar()->showMessage("Loaded: " + path);
 }

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -376,6 +376,7 @@ unique_ptr<CompoundStmt> Parser::parseCompoundStmt() {
 unique_ptr<CompoundStmt> Parser::parseBlockItems(int line, int col) {
     auto block = make_unique<CompoundStmt>(line, col);
     while (!input_.eof() && input_.peek().getType() != TokenType::RBRACE) {
+        size_t before = input_.getPos();
         if (isDeclarationStart(input_.peek().getType())) {
             auto decls = parseExternalDeclaration();
             for (auto& d : decls)
@@ -383,6 +384,12 @@ unique_ptr<CompoundStmt> Parser::parseBlockItems(int line, int col) {
         } else {
             auto stmt = parseStatement();
             if (stmt) block->addItem(move(stmt));
+        }
+        // Same contract as Parser::parse(): never spin if recovery left the
+        // cursor unchanged (expr stmt that ate nothing before a stray ')', etc.).
+        if (input_.getPos() == before && !input_.eof()
+            && input_.peek().getType() != TokenType::RBRACE) {
+            input_.get();
         }
     }
     return block;
@@ -634,6 +641,7 @@ vector<unique_ptr<Decl>> Parser::parseExternalDeclaration() {
     int col  = input_.peek().getColumn();
 
     Type baseType = parseDeclSpecifiers();
+    const size_t afterSpecifiers = input_.getPos();
 
     // First declarator
     Type firstType = baseType;
@@ -644,6 +652,19 @@ vector<unique_ptr<Decl>> Parser::parseExternalDeclaration() {
 
     // Function definition: declarator immediately followed by '('
     if (input_.peek().getType() == TokenType::LPAREN) {
+        // With no type specifier the "declaration" has kind INVALID. A pattern
+        // like `printf("hello");` is a call expression at file scope / implicit
+        // int typo — not `implicit-int foo() { }` (body follows ')' with '{').
+        if (baseType.getKind() == TypeKind::INVALID
+            && input_.matchingParenThenSemicolon()) {
+            input_.setPos(afterSpecifiers);
+            addError("expression cannot appear at file scope (only declarations "
+                     "and function definitions are valid here)",
+                    line, col, firstName);
+            (void)parseExpression();
+            expect(TokenType::SEMICOLON, "expected ';' after expression");
+            return {};
+        }
         auto fn = parseFunctionDecl(move(firstType), move(firstName), line, col);
         if (fn) result.push_back(move(fn));
         return result;

--- a/src/parser/TokenStream.cpp
+++ b/src/parser/TokenStream.cpp
@@ -60,3 +60,28 @@ bool TokenStream::check(TokenType expected) const {
 
 // Returns the current cursor index (for forward-progress checks in callers).
 size_t TokenStream::getPos() const { return pos_; }
+
+void TokenStream::setPos(size_t pos) {
+    pos_ = pos > tokens_.size() ? tokens_.size() : pos;
+}
+
+bool TokenStream::matchingParenThenSemicolon() const {
+    if (pos_ >= tokens_.size() || tokens_[pos_].getType() != TokenType::LPAREN)
+        return false;
+    int depth = 0;
+    for (size_t i = pos_; i < tokens_.size(); ++i) {
+        TokenType t = tokens_[i].getType();
+        if (t == TokenType::LPAREN)
+            ++depth;
+        else if (t == TokenType::RPAREN) {
+            --depth;
+            if (depth == 0) {
+                if (i + 1 < tokens_.size()
+                    && tokens_[i + 1].getType() == TokenType::SEMICOLON)
+                    return true;
+                return false;
+            }
+        }
+    }
+    return false;
+}

--- a/src/parser/TokenStream.h
+++ b/src/parser/TokenStream.h
@@ -45,6 +45,14 @@ public:
     // critical for forward-progress guarantees on garbage input.
     size_t getPos() const;
 
+    // Rewinds/advances the cursor (used when the parser backtracks on ambiguity).
+    void setPos(size_t pos);
+
+    // True iff peek() is '(' and the matching ')' is followed by ';' (balanced
+    // parens; only LPAREN/RPAREN tokens affect depth). Used to tell a call-like
+    // `id ( ... ) ;` from `id ( ... ) {` at file scope.
+    bool matchingParenThenSemicolon() const;
+
 private:
     const vector<Token>& tokens_;       // non-owning reference to the lexer's output
     size_t pos_;          // index of the next token to be read

--- a/tests/parser/test_parser.cpp
+++ b/tests/parser/test_parser.cpp
@@ -136,6 +136,19 @@ void testCheckIsPeekOnly() {
     ASSERT_EQ((int)s.peek().getType(), (int)TokenType::KW_INT, "check did not advance");
 }
 
+void testMatchingParenThenSemicolon() {
+    vector<Token> toks = {
+        Token(TokenType::IDENTIFIER,     "printf", 1, 1),
+        Token(TokenType::LPAREN,         "(",      1, 7),
+        Token(TokenType::STRING_LITERAL, "\"hi\"", 1, 8),
+        Token(TokenType::RPAREN,         ")",      1, 12),
+        Token(TokenType::SEMICOLON,      ";",      1, 13),
+    };
+    TokenStream s(toks);
+    (void)s.get();   // at '('
+    ASSERT_EQ(s.matchingParenThenSemicolon(), true, "...) ; after identifier");
+}
+
 // ---------- ParseError ----------
 
 void testParseErrorGetters() {
@@ -886,6 +899,16 @@ void testParseLongLong() {
               "long long collapses to long");
 }
 
+// Regression: `identifier ( ... ) ;` at file scope with no type specifier must
+// not be mis-parsed as a function definition (would spin inside the bogus body).
+void testParseFileScopeCallLikePrintf() {
+    ASSERT_EQ(parseTuDump(R"(printf("hello");)"),
+              string("TranslationUnit\n"),
+              "file-scope call: empty TU, tokens consumed");
+    ASSERT_EQ(parseTuErrorCount(R"(printf("hello");)") >= 1, true,
+              "file-scope expression reports at least one parse error");
+}
+
 void testParseFunctionEmptyParams() {
     ASSERT_EQ(parseTuDump("int main() { return 0; }"),
               string("TranslationUnit\n"
@@ -1153,6 +1176,7 @@ int main() {
     testMatchLeavesCursorOnMiss();
     testMatchAtEofIsFalse();
     testCheckIsPeekOnly();
+    testMatchingParenThenSemicolon();
 
     testParseErrorGetters();
     testParseErrorToStringWithText();
@@ -1227,6 +1251,7 @@ int main() {
     testParseStorageClassDiscarded();
     testParseUnsignedDiscarded();
     testParseLongLong();
+    testParseFileScopeCallLikePrintf();
     testParseFunctionEmptyParams();
     testParseFunctionVoidParams();
     testParseFunctionNamedParams();


### PR DESCRIPTION
## Summary
- Parser no longer hangs on file-scope calls like `printf(\"hello\");` — the token stream is now consumed via expression-fallback when no type specifiers are present, and `parseBlockItems` has a forward-progress guard.
- GUI window title is now consistently `C Compiler` (previously `Lexer` initially, `UNI-C Compiler  -  <file>` after open).

## Test plan
- [ ] `cmake --build build` succeeds on Windows and Linux (CI matrix)
- [ ] `ctest --output-on-failure` passes (LexerTests, ParserTests — includes new regression test for file-scope call hang)
- [ ] Launch GUI: window title reads `C Compiler` on open and `C Compiler  -  <file>` after loading a source file
- [ ] Run Lexer / Run Parser actions do not alter the window title